### PR TITLE
Various fixes

### DIFF
--- a/app/Controllers/Sites/UniversalPageController.php
+++ b/app/Controllers/Sites/UniversalPageController.php
@@ -41,7 +41,7 @@ class UniversalPageController extends BaseController
 		$this->setRequestResult($req, $res);
 
 		$this->data['subSections'] = Sections::getSubSections($this->data['pageData']->id);
-		$this->data['pagesLinks'] = Pages::where('category_id', $this->data['pageData']->id)->get();
+		$this->data['pagesLinks'] = Pages::where('category_id', $this->data['pageData']->id)->where('active', 1)->get();
 
 		$this->render('public\main\pages\section_page.twig');
 	}

--- a/app/Models/Users.php
+++ b/app/Models/Users.php
@@ -28,10 +28,7 @@ class Users extends BaseModel
 	}
 
 	public static function makePass($pass){
-		$options = [
-			    'cost' => 12,
-			    'salt' => mcrypt_create_iv(22, MCRYPT_DEV_URANDOM),
-			];
+		$options = ['cost' => 12];
 
 		return password_hash($pass, PASSWORD_BCRYPT, $options);
 	}

--- a/app/templates/admin/layouts/adddata.twig
+++ b/app/templates/admin/layouts/adddata.twig
@@ -3,16 +3,16 @@
 <div class="col-md-8">
     {% if type_link is defined %}
         <form action="{{ path_for(type_link) }}" method="POST" enctype="multipart/form-data">
+        {% set type = 'Edit' %}
     {% else %}
         <form action="{{ path_for(store_link) }}" method="POST" enctype="multipart/form-data">
+        {% set type = 'Add' %}
     {% endif %}
         <input name="{{csrf.valueKey}}" type="hidden" value="{{csrf.value}}">
         <input name="{{csrf.nameKey}}" type="hidden" value="{{csrf.name}}">
 
-    {% set type = 'Add' %}
     {#% for field in fields %}
         {% if field=='id' %}
-            {% set type = 'Edit' %}
             <input name="{{field}}" value="{{ fieldsValues[field] }}" class="form-control" type="hidden">
         {% else %}
             <div class="form-group">


### PR DESCRIPTION
1. UniversalPageController sets all pages for a given category in `pagesLinks`, but then PageFactory::getPageByCode, used to display the details page, gets only active pages

2. mcrypt_create_iv is removed in PHP 7.2. Moreover, it's recommended not to pass 'salt' to password_hash, which is deprecated as of PHP 7.0.0.

3. Since d48d79ffb226cce59df599bb33fd2ed9400e660f the `for` loop in which `type` variable is set, is not executed. So set the type variable the same way it's set in the addTables template