### PR TITLE
Do not check for id match in the category_id field

### DIFF
--- a/modules/Sections/Module.php
+++ b/modules/Sections/Module.php
@@ -63,9 +63,7 @@ class Module extends BaseModule
             $data = [];
 
             foreach ($arRes as $item) {
-                if( ($arItems['parent_id'] || null === $arItems['parent_id']) &&
-                      $item->id != $event->getParams()['fieldsValues']->id
-                ){
+                if (!array_key_exists('parent_id', $arItems) || $item->id != $event->getParams()['fieldsValues']->id) {
                     $data[$item->id] = $item->name;
                 }
             }


### PR DESCRIPTION
Curious bug: You can't select category for a page, that has the same ID as the page itself (e.g. page with ID 1 can not belong to section with ID 1; page with ID 2 can not belong to section with ID 2), etc.

This is because if the field is not `parent_id`, the value of `$arItems['parent_id']` is still null, as there is no such key.

So instead of checking the value, the existence of the key should be checked.

I'm not sure how this will work if category_id and parent_id were present in the same form, but for the current setup (sections having parent_id, while pages having category_id) this does the job.